### PR TITLE
add adjectives to the trope search

### DIFF
--- a/src/js/shared/search-films-header.html
+++ b/src/js/shared/search-films-header.html
@@ -1,0 +1,1 @@
+<h3 class="search-name">Films</h3>

--- a/src/js/shared/search-tropes-header.html
+++ b/src/js/shared/search-tropes-header.html
@@ -1,0 +1,1 @@
+<h3 class="search-name">Tropes</h3>

--- a/src/js/shared/search-tropes-suggestion.html
+++ b/src/js/shared/search-tropes-suggestion.html
@@ -1,0 +1,2 @@
+<p class="tt-suggestion-title"><%= name %></p>
+<p class="tt-suggestion-detail"><%= adjs.join(', ') %></p>

--- a/src/js/shared/search.js
+++ b/src/js/shared/search.js
@@ -9,14 +9,17 @@ define(function(require) {
   // but we need it to be required to bring in the
   // typeahead jquery plugin - so ignore the line.
   var typeahead = require('typeahead'); // jshint ignore:line
-
   var dataManager = require('../data/data_manager');
-
-  var template = require('tmpl!../shared/search');
+  var templates = {
+    main : require('tmpl!../shared/search'),
+    films_header : require('tmpl!../shared/search-films-header'),
+    tropes_header : require('tmpl!../shared/search-tropes-header'),
+    tropes_suggestion : require('tmpl!../shared/search-tropes-suggestion')
+  };
 
   return View.extend({
 
-    template: template,
+    template: templates.main,
     events: {
       'focus .typeahead' : 'onFocus',
       'typeahead:selected .typeahead' : 'onSelected'
@@ -74,10 +77,9 @@ define(function(require) {
         displayKey: 'name',
         source: tropes.ttAdapter(),
         templates: {
-          header: '<h3 class="search-name">Tropes</h3>',
-          suggestion: function(datum) { 
-            return '<p class="tt-suggestion-title">' + datum.name + "</p>" + 
-              '<p class="tt-suggestion-detail">' + datum.adjs.join(", ") + "</p>"; 
+          header: templates.tropes_header(),
+          suggestion: function(trope) { 
+            return templates.tropes_suggestion(trope);
           }
         }
       },
@@ -86,7 +88,7 @@ define(function(require) {
         displayKey: 'name',
         source: films.ttAdapter(),
         templates: {
-          header: '<h3 class="search-name">Films</h3>'
+          header: templates.films_header()
         }
       });
     },


### PR DESCRIPTION
add adjectives back to trope search.
also clears searchbar on focus - so you can easily search for something new.

![screen shot 2015-02-27 at 12 22 58 pm](https://cloud.githubusercontent.com/assets/9369/6420506/846946a6-be7b-11e4-8e2a-72988cf41623.png)
