### PR TITLE
Make the trope detail page take an option to specify where the "read mor...

### DIFF
--- a/src/js/pages/adjectives/adjectives-page.js
+++ b/src/js/pages/adjectives/adjectives-page.js
@@ -78,7 +78,11 @@ define(function(require) {
           var el = $('.blurb');
 
           self.tile = new TropeTile({ trope_id : tropeId });
-          self.tropeDesc = new TropeDetails({ trope_id : tropeId });
+          self.tropeDesc = new TropeDetails({
+            trope_id : tropeId,
+            trope_url : '/tropes/' + tropeId,
+            same_tab : true
+          });
 
           // var pp = self.tile.render();
           // console.log('trope details promise', pp)

--- a/src/js/pages/trope/trope-detail-header.html
+++ b/src/js/pages/trope/trope-detail-header.html
@@ -4,5 +4,5 @@
   <div class="description short collapsed">
     <%= description %>
   </div>
-  <a class="more" href="http://tvtropes.org/pmwiki/pmwiki.php/Main/<%= id %>" target="_blank">Read More</a>
+  <a class="more" href=<%= trope_url %> target=<%= url_target %>>Read More</a>
 <% } %>

--- a/src/js/pages/trope/trope-detail-header.js
+++ b/src/js/pages/trope/trope-detail-header.js
@@ -18,6 +18,14 @@ define(function(require) {
       };
 
       this.trope_id = options.trope_id;
+
+      if (options.trope_url) {
+        this.trope_url = options.trope_url;
+      } else {
+        this.trope_url = "http://tvtropes.org/pmwiki/pmwiki.php/Main/" + this.trope_id;
+      }
+
+      this.same_tab = options.same_tab;
     },
 
     _preDataRender: function() {
@@ -32,6 +40,8 @@ define(function(require) {
       return dataManager.getTropeDetails(this.trope_id).then(function(trope_details) {
         self.trope_data = trope_details;
         self.trope_data.loading = false;
+        self.trope_data.trope_url = self.trope_url;
+        self.trope_data.url_target = (self.same_tab ? '' : '_blank');
         self.$el.html(self.template(self.trope_data));
         return self;
       });


### PR DESCRIPTION
...e" link should go and whether it should open in a new tab.

This lets us link from the adjectives page to the trope page in our site.

@iros do take a look when you get a chance. 
