### PR TITLE
fix fragment links to open new pages when command clicked

### DIFF
--- a/src/js/main.js
+++ b/src/js/main.js
@@ -4,6 +4,7 @@ define(function(require, exports, module) {
   var Backbone = require('backbone');
   var $ = require('jquery');
   var Router = require('./core/router');
+  var openLinkInTab = false;
 
   new Router();
 
@@ -12,17 +13,36 @@ define(function(require, exports, module) {
     root: "/"
   });
 
+  $(document).keydown(function(event) {
+    if (event.ctrlKey || event.keyCode === 91) {
+      openLinkInTab = true;
+    }
+  });
+
+  $(document).keyup(function(event) {
+    openLinkInTab = false;
+  });
+
   // All navigation that is relative should be passed through the navigate
   // method, to be processed by the router. If the link has a `data-bypass`
   // attribute, bypass the delegation completely.
   $(document).on("click", "a[href^='#']:not([data-bypass])", function(evt) {
+
     // Prevent the default event (including page refresh).
     evt.preventDefault();
 
-    // `Backbone.history.navigate` is sufficient for all Routers and will
-    // trigger the correct events. The Router's internal `navigate` method
-    // calls this anyways. The fragment is sliced from the root.
     var href = $(this).attr("href");
-    Backbone.history.navigate(href, true);
+    if (!openLinkInTab) {
+
+      // `Backbone.history.navigate` is sufficient for all Routers and will
+      // trigger the correct events. The Router's internal `navigate` method
+      // calls this anyways. The fragment is sliced from the root.
+      Backbone.history.navigate(href, true);
+    } else {
+      if (href.indexOf('#') === 0) {
+        href = href.slice(1); // remove # from the url
+        window.open("/" + href, "_blank"); // open new blank target window
+      }
+    }
   });
 });


### PR DESCRIPTION
Our previous solution didn't work, because it was binding to urls that assumed there were no fragments. Since we're supporting fragments here, we need to do something different when we encounter a fragmented url.

@tbranyen can you chime in here since it modifies your original code? I'd love your feedback.
