### PR TITLE
remove outline on in-active links

### DIFF
--- a/src/styles/shared.styl
+++ b/src/styles/shared.styl
@@ -118,6 +118,7 @@ nav {
 
     .inactive {
       color: $silver-blue-dark;
+      outline: none;
     }
   }
 


### PR DESCRIPTION
little change to make active links in nav bar not have distracting css border around them on initial click.

Go from:
![screen shot 2015-03-31 at 8 23 14 am](https://cloud.githubusercontent.com/assets/9369/6922408/c087c794-d77f-11e4-9a5e-41b7342ce158.png)
to:
![screen shot 2015-03-31 at 8 23 19 am](https://cloud.githubusercontent.com/assets/9369/6922411/c7033a5e-d77f-11e4-9c56-2d64872ad859.png)
