### PR TITLE
remove query string from tracking url

### DIFF
--- a/src/js/core/router.js
+++ b/src/js/core/router.js
@@ -120,9 +120,7 @@ define(function(require) {
     },
 
     _track: function() {
-      var url = Backbone.history.root + Backbone.history.getFragment();
-      // remove query string
-      url = url.split("?")[0];
+      var url = window.location.pathname;
       if (url === "/") {
         url = "/tropes";
       }


### PR DESCRIPTION
the query string adds spurious pages under adjectives and films, fragmenting the analysis.
