### PR TITLE
Update library dependency

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -28,7 +28,7 @@
     "pure": "~0.5.0",
     "d3": "~3.5.5",
     "backbone": "~1.1.2",
-    "lodash-template-loader": "~0.1.7",
+    "lodash-template-loader": "~0.1.9",
     "requirejs": "~2.1.16",
     "jquery": "~2.1.3",
     "lodash": "~2.4.1",


### PR DESCRIPTION
The 0.1.8 release of the `lodash-template-loader` library contained a
backwards-breaking change. A fix has since been published; update the
dependency to explicitly avoid installation of that version.

Alternatively, you could update Lodash to version 3.0. That's probably the best long-term fix, but it's not one I am comfortable making as a drive-by contribution, and it may also require more thorough vetting than the project's current release schedule allows.
