### PR TITLE
first pass at trope for mobile 

### DIFF
--- a/src/js/pages/trope/trope-adj-ll-scale.html
+++ b/src/js/pages/trope/trope-adj-ll-scale.html
@@ -3,7 +3,7 @@
 <% } else { %>
   <div class="pure-u-1-1 preface">
     <h3>adjectives describing this trope</h3>
-    <div class="pure-u-16-24">
+    <div class="pure-u-1-1 pure-u-md-16-24 hide-small">
       <p>
       The description above is a short snippet of what was written about this trope on <a href="http://tvtropes.org" target="_blank">tvtropes.org</a>. We wanted to examine more closely the adjectives used in the full description. Adjectives closer to the left are more associated only with this trope, and ones further to the right are more generic. Those adjectives that have <span class="gender-m">blue</span> or <span class="gender-f">pink</span> triangles beneath them appear only in this trope, and nowhere else. Read about how we found these associations <a href="#about">here</a>.
       </p>
@@ -16,6 +16,11 @@
       Less strongly associated with this trope &#8594;
     </div>
     <div class="vis pure-u-1-1">
+    </div>
+    <div class="pure-u-1-1 pure-u-md-16-24 show-small">
+      <p class="faded preface">
+      Adjectives closer to the left are more associated only with this trope, and ones further to the right are more generic. <span class="gender-m">Blue</span> or <span class="gender-f">Pink</span> triangles indicate adjectives unique to this trope. Read more <a href="#about">here</a>.
+      </p>
     </div>
 <% } %>
 

--- a/src/js/pages/trope/trope-detail-header.html
+++ b/src/js/pages/trope/trope-detail-header.html
@@ -5,5 +5,5 @@
   <div class="description short collapsed">
     <%= description %>
   </div>
-  <a class="more" href=<%= trope_url %> target=<%= url_target %>>Read more on tvtropes.org &raquo;</a>
+  <a class="more" href=<%= trope_url %> target=<%= url_target %>><span class="hide-small">Read more on </span>tvtropes.org &raquo;</a>
 <% } %>

--- a/src/js/pages/trope/trope-page.html
+++ b/src/js/pages/trope/trope-page.html
@@ -1,10 +1,10 @@
 <div class="page trope-page">
   <div class="trope-header pure-g">
-    <div class="pure-u-16-24">
+    <div class="pure-u-1-1 pure-u-md-16-24">
       <div class="trope-tile-container"></div>
       <div class="trope-detail-container"></div>
     </div>
-    <div class="trope-timeline-container pure-u-8-24"></div>
+    <div class="trope-timeline-container pure-u-1-1 pure-u-md-8-24"></div>
   </div>
   <div class="gender-split-bar-container"></div>
   <div class="trope-adjectives-timeline pure-u-1-1">

--- a/src/styles/shared.styl
+++ b/src/styles/shared.styl
@@ -6,6 +6,7 @@ html, button, input, select, textarea,
     font-size: 14px;
 }
 
+
 h1, h2, h3, h4, h5 {
   font-weight: 500;
   margin-top:0;
@@ -29,6 +30,14 @@ h4 {
 
 body {
   padding:20px;
+}
+
+@media screen and (max-width:567px) {
+  .hide-small{display:none;}
+}
+
+@media screen and (min-width:568px) {
+  .show-small{display:none;}
 }
 
 a, a:visited{
@@ -80,6 +89,9 @@ aside {
   padding-bottom: 30px;
 }
 
+.faded {
+  color: $grey;
+  }
 
 
 // Top level nav
@@ -265,4 +277,5 @@ trope-tile(tileWidth, tileHeight) {
     float:right;
   }
 }
+
 


### PR DESCRIPTION
deals with #167
strategy for this page in this pass:
- use pure css classes to get timeline below image and description on mobile
- move text about adjectives vis to be below the vis itself on mobile
- shorten and grey out text about adjectives vis on mobile
- shorten "read more on tvtropes.org" to just "tvtropes.org" on mobile

Haven' tested on actual device yet.

![screen shot 2015-04-01 at 2 59 12 pm](https://cloud.githubusercontent.com/assets/9369/6953785/940760b0-d880-11e4-96c1-194dda0f1dd1.png)

---

![screen shot 2015-04-01 at 3 05 59 pm](https://cloud.githubusercontent.com/assets/9369/6953801/abb580a2-d880-11e4-8cd8-d6c2e160b5bc.png)

thoughts? concerns? improvements? @iros @tafsiri 
