### PR TITLE
Unify text treatment on application landing page

### DIFF
--- a/src/js/pages/tropes/tropes-page-intro.html
+++ b/src/js/pages/tropes/tropes-page-intro.html
@@ -2,7 +2,7 @@
   <div>
     <p>
       Some of the greatest reflections on society take place in film, through complex characters, often falling into familiar patterns called “Tropes”.
-      Tropes are devices and conventions that a writer can rely on as being present in the audience’s minds. Stereotropes is an interactive experiment, exploring a set of tropes authored by the community on <a href='http://tvtropes.org' alt='tvtropes website'>tvtropes.org</a> that are categorized as being <a data-gender='f' class='gender-filter f'>always female</a> or <a data-gender='m' class='gender-filter m'>always male</a>.
+      Tropes are devices and conventions that a writer can rely on as being present in the audience’s minds. <br> <em>Stereotropes</em> is an interactive experiment, exploring a set of tropes authored by the community on <a href='http://tvtropes.org' alt='tvtropes website'>tvtropes.org</a> that are categorized as being <a data-gender='f' class='gender-filter f'>always female</a> or <a data-gender='m' class='gender-filter m'>always male</a>.
     </p>
   </div>
 </div>

--- a/src/styles/tropes-page.styl
+++ b/src/styles/tropes-page.styl
@@ -96,10 +96,14 @@
 
         &.f {
           background-color: $female-col;
+          padding-top: 1px;
+          padding-bottom: 1px;
         }
 
         &.m {
           background-color: $male-col;
+          padding-top: 1px;
+          padding-bottom: 1px;
         }
       }
 
@@ -111,9 +115,9 @@
       p {
         margin: 0;
 
-        font-size: 16px;
+        font-size: 15px;
         font-weight: 300;
-        line-height: 1.4;
+        line-height: 1.6;
         padding-right: 15px;
 
       }
@@ -132,18 +136,19 @@
       p {
         margin: 0;
 
-        font-size: 16px;
+        font-size: 15px;
         font-weight: 300;
-        line-height: 1.4;
+        line-height: 1.6;
         padding-right: 15px;
 
       }
     }
 
     .text-tile .intro p {
-      font-size: 16px;
+      font-size: 15px;
       font-weight: 300;
-      line-height: 1.4;
+      line-height: 1.6;
+      margin-top: 0;
     }
   }
 


### PR DESCRIPTION
## The intro copy and the text in the grid squares are different weights/line height:
## ![image](https://cloud.githubusercontent.com/assets/442115/7272796/aec743b6-e8bb-11e4-8398-23dc17217974.png)

The difference is that the text in the grid gets hit by these styles:

``` css
@media screen and (max-width: 1024px) and (min-width: 768px) {
  .tropes-page .tropes-container .text-tile.filter p {
    font-size: .95em;
    line-height: 1.6em;
  }
}
.tropes-page .tropes-container .text-tile.filter p {
  font-weight: 300;
}
```
## If `.intro p` is given the same treatment, things even out a bit:
## ![image](https://cloud.githubusercontent.com/assets/442115/7273311/73ea733a-e8c0-11e4-8ef4-fa35f4c0bb51.png)

Changing the base line-height to 1.4 fixed a text overflow issue that this PR reintroduced; using unit-less line heights should have no impact here, but is [recommended by MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/line-height#Prefer_unitless_numbers_for_line-height_values).

**I have _not_ tested this exhaustively across browsers.** Discretion advised. (sorry, haven't had time)
